### PR TITLE
missing condition for skill-related variables

### DIFF
--- a/1_antenatal_care.do
+++ b/1_antenatal_care.do
@@ -32,7 +32,7 @@ order *,sequential
 	replace c_anc_ear_q = 0 if c_anc_ear == 0 & c_anc_any == 1
 	
 	*anc_skill: Categories as skilled: doctor, nurse, midwife, auxiliary nurse/midwife...
-	foreach var of varlist m2a-m2n {
+	foreach var of varlist m2a-m2m {
 	local lab: variable label `var' 
     replace `var' = . if ///
         !regexm("`lab'","trained") & ///
@@ -55,7 +55,7 @@ order *,sequential
 	
 	*c_anc_ski: antenatal care visit with skilled provider for pregnancy of births in last 2 years
 	gen c_anc_ski = .
-	replace c_anc_ski = 1 if anc_skill >= 1
+	replace c_anc_ski = 1 if anc_skill >= 1 & anc_skill!=.
 	replace c_anc_ski = 0 if anc_skill == 0
 	
 	*c_anc_ski_q: antenatal care visit with skilled provider among ANC users for pregnancy of births in last 2 years

--- a/2_delivery_care.do
+++ b/2_delivery_care.do
@@ -57,7 +57,7 @@ order *,sequential  //make sure variables are in order.
 	
 	*c_sba: Skilled birth attendance of births in last 2 years: go to report to verify how "skilled is defined"
 	gen c_sba = . 
-	replace c_sba = 1 if sba_skill>=1 
+	replace c_sba = 1 if sba_skill>=1 & sba_skill!=. 
 	replace c_sba = 0 if sba_skill==0 
 	  
 	*c_sba_q: child placed on mother's bare skin and breastfeeding initiated immediately after birth among children with sba of births in last 2 years

--- a/8_child_illness.do
+++ b/8_child_illness.do
@@ -69,13 +69,13 @@ order *,sequential  //make sure variables are in order.
 
 *c_diarrhea_medfor Get formal medicine except (ors hmf home other_med, country specific). 
         egen medfor = rowtotal(h12z h15 h15a h15b h15c h15e h15g h15h ),mi
-		gen c_diarrhea_medfor = ( medfor > = 1 ) if c_diarrhea == 1
+		gen c_diarrhea_medfor = ( medfor > = 1 & medfor!=.) if c_diarrhea == 1
 		// formal medicine don't include "home remedy, herbal medicine and other"
         replace c_diarrhea_medfor = . if (h12z == 8 | h15 == 8 | h15a == 8 | h15b == 8 | h15c == 8 | h15e == 8  | h15g == 8 | h15h == 8  )                                       
 
 *c_diarrhea_med	Child with diarrhea received any medicine other than ORS or hmf (country specific)
         egen med = rowtotal(h12z h15 h15a h15b h15c h15d h15e h15f h15g h15h),mi
-        gen c_diarrhea_med = ( med > = 1 ) if c_diarrhea == 1
+        gen c_diarrhea_med = ( med > = 1 & medfor!=.) if c_diarrhea == 1
         replace c_diarrhea_med = . if (h12z == 8 | h15 == 8 | h15a == 8 | h15b == 8 | h15c == 8 | h15d == 8 | h15e == 8 | h15f == 8 | h15g == 8 | h15h == 8 )
 		
 *c_diarrheaact	Child with diarrhea seen by provider OR given any form of formal treatment


### PR DESCRIPTION
This applies to several skilled related variables. Take c_sba as an example. sba_skill>=1 includes observation that sba_skill==. 
The original code will treat cases where m3a-m3m ==. as c_sba =1. 
Thus I suggest adding condition, "& sba_skill!=." 